### PR TITLE
Fix a variety of issues and setup _quarto.yml

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -13,6 +13,21 @@ website:
   margin-header: |
     ![](/logo.png)
   favicon: /logo.png
+  repo-url: https://github.com/muellerzr/nbquarto
+  issue-url: https://github.com/muellerzr/nbquarto/issues/new
+  repo-actions: [edit, issue]
+  page-navigation: true
+
+  page-footer: 
+    right:
+      - icon: github
+        href: https://github.com/muellerzr/nbquarto
+        aria-label: nbquarto GitHub
+  navbar:
+    tools:
+      - icon: github
+        href: https://github.com/muellerzr/nbquarto
+        aria-label: nbquarto GitHub
 
 format:
   html:

--- a/docs/getting_started.qmd
+++ b/docs/getting_started.qmd
@@ -24,13 +24,12 @@ pip install git+https://github.com/muellerzr/nbquarto
 To use `nbquarto`, you must first create a `config.yaml` file to serve as the 
 project configuration. This file can be placed anywhere.
 
-For example, located [here](config.yaml) in the repo:
+For example, located [here](https://github.com/muellerzr/nbquarto/blob/main/config.yaml) in the repo:
 
 ```yaml
 documentation_source: nbs
 output_folder: docs
 processors: [
-    nbquarto.processors.example:BasicProcessor,
     nbquarto.processors.autodoc:AutoDocProcessor
 ]
 

--- a/src/nbquarto/processors/autodoc.py
+++ b/src/nbquarto/processors/autodoc.py
@@ -250,7 +250,7 @@ def autodoc(object_name, package, methods=None, page_info=None, version_tag_suff
 class AutoDocProcessor(Processor):
     """
     A processor which will automatically generate API documentation for a given class or method.
-    Largely relies on the implementation in [hf-doc-builder](https://github.comn/huggingface/doc-builder),
+    Largely relies on the implementation in [hf-doc-builder](https://github.com/huggingface/doc-builder),
     while adding some customizations for Quarto.
 
     This processor expects the following directives:


### PR DESCRIPTION
Solves https://github.com/muellerzr/nbquarto/issues/1 by:

- Adds a variety of metadata in `_quarto.yml` to get clear links to the github
- Fixes URL to the `config.yml` in the Getting Started
- Solves typo in `AutoDocProcessor`