### PR TITLE
🚨 🚨 🚨 Change processors to notebook_processors, introduce post processors 🚨 🚨 🚨 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 documentation_source: nbs
 output_folder: docs
-processors: [
-    nbquarto.processors.autodoc:AutoDocProcessor
+notebook_processors: [
+    nbquarto.processors:AutoDocProcessor,
 ]
 
 processor_args:

--- a/docs/getting_started.qmd
+++ b/docs/getting_started.qmd
@@ -29,7 +29,7 @@ For example, located [here](https://github.com/muellerzr/nbquarto/blob/main/conf
 ```yaml
 documentation_source: nbs
 output_folder: docs
-processors: [
+notebook_processors: [
     nbquarto.processors.autodoc:AutoDocProcessor
 ]
 
@@ -42,7 +42,7 @@ This reads as follows:
 
 - `output_folder`: All notebooks will be saved to a (potentially new) `processed_notebooks` directory
 
-- `processors`: This contains the list of processors we want to apply
+- `notebook_processors`: This contains the list of processors we want to apply on notebooks specifically
   
   - `nbquarto.processors.example:BasicProcessor` and `nbquarto.processors.autodoc:AutoDocProcessor`: This is the exact import for the processor to apply. Can also be relative if the package is setup for it (so it could be `nbquarto.processors:AutoDocProcessor`)
 - `processor_args`: This contains a list of `processor`: `args` that should be passed all the time to a particular processor, if it takes in special configuration arguments
@@ -104,7 +104,7 @@ To then use it in your own framework, simply add it to your `config.yaml` file a
 ```yaml
 documentation_source: nbs
 output_folder: docs
-processors: [
+notebook_processors: [
     module.to.processor:BasicProcessor,
 ]
 ```
@@ -128,7 +128,7 @@ class ProcessorWithArgs(Processor):
 ```yaml
 documentation_source: nbs
 output_folder: docs
-processors: [
+notebook_processors: [
     module.to.processor:ProcessorWithArgs,
 ]
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -62,7 +62,7 @@ Say goodbye to confusion with `nbquarto`'s configuration file. This handy featur
 
 ```yaml
 documentation_source: tests
-processors: [
+notebook_processors: [
     nbquarto.processors.example:BasicProcessor,
     nbquarto.processors.autodoc:AutoDocProcessor
 ]

--- a/docs/package_reference/processor.qmd
+++ b/docs/package_reference/processor.qmd
@@ -100,8 +100,51 @@ correct type and contains the correct directive
 
 <div style="background:#f7f7f7; border:2px solid #5a5a5a; border-top-width:2px; border-left-width: 2px; border-top-left-radius: 0.75rem; margin-top: 2rem; margin-bottom: 1.5rem; padding-left: 1rem; padding-right: .5rem;">
 
-### `class NotebookProcessor` {#nbquarto.processor.NotebookProcessor}
+### `class RawPostProcessor` {#nbquarto.processor.RawPostProcessor}
 [\<source\>](https://github.com/muellerzr/nbquarto/blob/main/src/nbquarto/processor.py#L110){style="float:right;font-size:.875rem;"}
+<p style="font-size:.875rem;line-height:1.25rem;">
+(**`content`**`: str`)
+</p>
+
+<div style="font-size:.875rem;line-height:1.25rem;margin-bottom:1.25em; margin-top:1.25em; padding_bottom:0;">
+
+A processor class which deals with modifying the raw `.qmd` files
+directly. These are ran *after* the notebook has been processed
+and converted to a `.qmd` file.
+
+Similar to the `Processor` class, you should implement a 
+`process` function to be called, however here it will 
+just always be called and should modify the raw string
+text, which is stored in `self.content`. 
+
+Will **always** be ran on each notebook if enabled for the 
+project.
+
+</div><div style="background:#f7f7f7; border:2px solid #5a5a5a; border-top-width:2px; border-left-width: 2px; border-top-left-radius: 0.75rem; margin-top: 2rem; margin-bottom: 1.5rem; padding-left: 1rem; padding-right: .5rem;">
+#### `process` {#nbquarto.processor.RawPostProcessor.process}
+[\<source\>](https://github.com/muellerzr/nbquarto/blob/main/src/nbquarto/processor.py#L133){style="float:right;font-size:.875rem;"}
+<p style="font-size:.875rem;line-height:1.25rem;">
+()
+</p>
+
+<div style="font-size:.875rem;line-height:1.25rem;margin-bottom:1.25em; margin-top:1.25em; padding_bottom:0;">
+
+A function to apply `self.content`.
+
+Example:
+```python
+def process(self):
+    self.content = f'Founda  directive!\n{self.content}'
+```
+
+</div></div>
+
+</div>
+
+<div style="background:#f7f7f7; border:2px solid #5a5a5a; border-top-width:2px; border-left-width: 2px; border-top-left-radius: 0.75rem; margin-top: 2rem; margin-bottom: 1.5rem; padding-left: 1rem; padding-right: .5rem;">
+
+### `class NotebookProcessor` {#nbquarto.processor.NotebookProcessor}
+[\<source\>](https://github.com/muellerzr/nbquarto/blob/main/src/nbquarto/processor.py#L152){style="float:right;font-size:.875rem;"}
 <p style="font-size:.875rem;line-height:1.25rem;">
 (**`path`**`: str = None`, **`processors`**`: list = []`, **`notebook`**`: AttributeDictionary = None`, **`config`**`: dict = {}`, **`debug`**`: bool = False`, **`remove_directives`**`: bool = True`, **`process_immediately`**`: bool = False`)
 </p>
@@ -131,7 +174,7 @@ Processes notebook cells and comments in a notebook
 
 </div><div style="background:#f7f7f7; border:2px solid #5a5a5a; border-top-width:2px; border-left-width: 2px; border-top-left-radius: 0.75rem; margin-top: 2rem; margin-bottom: 1.5rem; padding-left: 1rem; padding-right: .5rem;">
 #### `process_cell` {#nbquarto.processor.NotebookProcessor.process_cell}
-[\<source\>](https://github.com/muellerzr/nbquarto/blob/main/src/nbquarto/processor.py#L155){style="float:right;font-size:.875rem;"}
+[\<source\>](https://github.com/muellerzr/nbquarto/blob/main/src/nbquarto/processor.py#L198){style="float:right;font-size:.875rem;"}
 <p style="font-size:.875rem;line-height:1.25rem;">
 (**`processor`**`: callable`, **`cell`**`: AttributeDictionary`)
 </p>
@@ -151,7 +194,7 @@ explicitly and instead a user should use `process_notebook`
 </div></div>
 <div style="background:#f7f7f7; border:2px solid #5a5a5a; border-top-width:2px; border-left-width: 2px; border-top-left-radius: 0.75rem; margin-top: 2rem; margin-bottom: 1.5rem; padding-left: 1rem; padding-right: .5rem;">
 #### `process_notebook` {#nbquarto.processor.NotebookProcessor.process_notebook}
-[\<source\>](https://github.com/muellerzr/nbquarto/blob/main/src/nbquarto/processor.py#L173){style="float:right;font-size:.875rem;"}
+[\<source\>](https://github.com/muellerzr/nbquarto/blob/main/src/nbquarto/processor.py#L216){style="float:right;font-size:.875rem;"}
 <p style="font-size:.875rem;line-height:1.25rem;">
 ()
 </p>

--- a/docs/package_reference/processors.qmd
+++ b/docs/package_reference/processors.qmd
@@ -6,6 +6,7 @@ jupyter: python3
 > The various `Processor` classes available to use
 
 
+## Processors for Notebooks
 <div style="background:#f7f7f7; border:2px solid #5a5a5a; border-top-width:2px; border-left-width: 2px; border-top-left-radius: 0.75rem; margin-top: 2rem; margin-bottom: 1.5rem; padding-left: 1rem; padding-right: .5rem;">
 
 ### `class BasicProcessor` {#nbquarto.processors.example.BasicProcessor}
@@ -142,18 +143,22 @@ This function adds two numbers together
 ::::
 :::
 
+## Post Processors
+
+Post processors get applied after all regular processors get applied, and are performed on the output `.qmd` files across the entire *project*.
 <div style="background:#f7f7f7; border:2px solid #5a5a5a; border-top-width:2px; border-left-width: 2px; border-top-left-radius: 0.75rem; margin-top: 2rem; margin-bottom: 1.5rem; padding-left: 1rem; padding-right: .5rem;">
 
 ### `class SemanticVersioningProcessor` {#nbquarto.processors.SemanticVersioningProcessor}
 [\<source\>](https://github.com/muellerzr/nbquarto/blob/main/src/nbquarto/processors/semantic_versioning.py#L65){style="float:right;font-size:.875rem;"}
 <p style="font-size:.875rem;line-height:1.25rem;">
-(**`notebook`**`: AttributeDictionary`)
+(**`content`**`: str`)
 </p>
 
 <div style="font-size:.875rem;line-height:1.25rem;margin-bottom:1.25em; margin-top:1.25em; padding_bottom:0;">
 
-A processor which will inject javascript into the top of the `qmd` or
-notebook to enable semantic versioning of the documentation.
+A processor which will inject javascript into the top of the `qmd`
+to enable semantic versioning of the documentation by hiding parts
+of the sidebar.
 
 Assumes your documentation structure is as follows:
 

--- a/nbs/package_reference/processor.ipynb
+++ b/nbs/package_reference/processor.ipynb
@@ -23,6 +23,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#| autodoc nbquarto.processor.RawPostProcessor"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#| autodoc nbquarto.processor.NotebookProcessor"
    ]
   },

--- a/nbs/package_reference/processors.ipynb
+++ b/nbs/package_reference/processors.ipynb
@@ -14,6 +14,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Processors for Notebooks"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#| autodoc nbquarto.processors.example.BasicProcessor"
    ]
   },
@@ -83,6 +91,16 @@
     "This function adds two numbers together\n",
     "::::\n",
     ":::\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Post Processors\n",
+    "\n",
+    "Post processors get applied after all regular processors get applied, and are performed on the output `.qmd` files across the entire *project*."
    ]
   },
   {

--- a/src/nbquarto/cli.py
+++ b/src/nbquarto/cli.py
@@ -57,17 +57,18 @@ def process_notebook(notebook_location: str, config_file: str, output_folder: st
     config = get_configuration(config_file)
 
     # Bring in the processors
-    logger.debug("Importing processors")
-    processors = config.get("processors", [])
-    for i, processor in enumerate(processors):
+    logger.debug("Importing notebook processors")
+    notebook_processors = config.get("notebook_processors", [])
+    for i, processor in enumerate(notebook_processors):
         module_location, class_name = processor.split(":")
         module = __import__(module_location, fromlist=[class_name])
-        processors[i] = getattr(module, class_name)
+        notebook_processors[i] = getattr(module, class_name)
 
     # Process and save the new notebook
-    logger.debug(f"Processing notebook {notebook_location} with processors: {processors}")
-    notebook_processor = NotebookProcessor(notebook_location, processors=processors, config=config)
+    logger.debug(f"Processing notebook {notebook_location} with processors: {notebook_processors}")
+    notebook_processor = NotebookProcessor(notebook_location, processors=notebook_processors, config=config)
     notebook_processor.process_notebook()
+
     if output_folder is None:
         if "output_folder" not in config:
             logger.warn(
@@ -118,11 +119,34 @@ def process_notebook(notebook_location: str, config_file: str, output_folder: st
 
     # Join the markdown lines into a single string
     md_source = "\n".join(md)
+
     output_location = output_location.with_suffix(".qmd")
 
     with open(output_location, "w") as f:
         f.write(md_source)
     logger.info(f"Successfully processed notebook at {notebook_location} and saved to {output_location}")
+
+
+def process_qmd(qmd_location: str, config: dict):
+    # Bring in the processors
+    logger.debug("Importing and applying qmd processors")
+    qmd_processors = config.get("qmd_processors", [])
+    for i, processor in enumerate(qmd_processors):
+        if isinstance(processor, str):
+            module_location, class_name = processor.split(":")
+            module = __import__(module_location, fromlist=[class_name])
+            qmd_processors[i] = getattr(module, class_name)
+
+    with open(qmd_location, "r") as f:
+        qmd_source = f.read()
+
+    # Process and save the new notebook
+    for processor in qmd_processors:
+        processor = processor(qmd_source)
+        qmd_source = processor.process()
+
+    with open(qmd_location, "w") as f:
+        f.write(qmd_source)
 
 
 def main():
@@ -156,3 +180,15 @@ def main():
                 process_notebook(path, args.config_file, args.output_folder)
     else:
         process_notebook(args.notebook_file, args.config_file, args.output_folder)
+
+    config = get_configuration(args.config_file)
+
+    if len(config.get("qmd_processors", [])) > 0:
+        if args.output_folder is None:
+            doc_path = config.get("output_folder", "processed")
+        else:
+            doc_path = args.output_folder
+        for file in Path(doc_path).glob("**/*"):
+            if file.is_file() and file.suffix == ".qmd":
+                process_qmd(file, config)
+                logger.info(f"Successfully postprocessed {file}")

--- a/src/nbquarto/cli.py
+++ b/src/nbquarto/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import warnings
 from pathlib import Path
 
 import yaml
@@ -58,7 +59,13 @@ def process_notebook(notebook_location: str, config_file: str, output_folder: st
 
     # Bring in the processors
     logger.debug("Importing notebook processors")
-    notebook_processors = config.get("notebook_processors", [])
+    if config.get("processors", None) is not None:
+        warnings.warn(
+            "Using `processors` as a key in the `config.yaml` will be deprecated in `0.1.0`. Please use `notebook_processors` instead."
+        )
+        notebook_processors = config.get("processors")
+    else:
+        notebook_processors = config.get("notebook_processors", [])
     for i, processor in enumerate(notebook_processors):
         module_location, class_name = processor.split(":")
         module = __import__(module_location, fromlist=[class_name])

--- a/src/nbquarto/processor.py
+++ b/src/nbquarto/processor.py
@@ -107,6 +107,50 @@ class Processor:
         return self.process_cell(cell)
 
 
+class RawPostProcessor:
+    """
+    A processor class which deals with modifying the raw `.qmd` files
+    directly. These are ran *after* the notebook has been processed
+    and converted to a `.qmd` file.
+
+    Similar to the `Processor` class, you should implement a
+    `process` function to be called, however here it will
+    just always be called and should modify the raw string
+    text, which is stored in `self.content`.
+
+    Will **always** be ran on each notebook if enabled for the
+    project.
+    """
+
+    content: str = None
+
+    def __init__(self, content: str):
+        """
+        Args:
+            content (`str`):
+                The raw text of a `.qmd` file
+        """
+        self.content = content
+
+    def process(self):
+        """
+        A function to apply `self.content`.
+
+        Example:
+        ```python
+        def process(self):
+            self.content = f'Founda  directive!\\n{self.content}'
+        ```
+        """
+        raise NotImplementedError("You must implement the `process` method to apply this processor")
+
+    def __call__(self):
+        """
+        Processes the raw text of a `.qmd` file and returns the content
+        """
+        return self.process()
+
+
 class NotebookProcessor:
     """
     Processes notebook cells and comments in a notebook
@@ -147,6 +191,7 @@ class NotebookProcessor:
             cell.directives_ = extract_directives(cell, remove_directives=remove_directives, language=self.language)
         processor_args = config.get("processor_args", {})
         self.processors = make_processors(processors, notebook=self.notebook, processor_args=processor_args)
+        self.post_processors = config.get("post_processors", [])
         self.debug = debug
         self.remove_directives = remove_directives
         if process_immediately:

--- a/tests/test_artifacts/single_processor.yaml
+++ b/tests/test_artifacts/single_processor.yaml
@@ -1,6 +1,6 @@
 
 documentation_source: tests
-processors: [
+notebook_processors: [
     nbquarto.processors.example:BasicProcessor,
     nbquarto.processors.autodoc:AutoDocProcessor
 ]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -123,40 +123,8 @@ class TestAutoDoc(unittest.TestCase):
 class TestSemanticVersioning(unittest.TestCase):
     processor = SemanticVersioningProcessor
 
-    def reset_cells(self):
-        test_cells = [
-            make_cell("# Test Notebook", "markdown"),
-            make_cell("Here's some text!", "markdown"),
-        ]
-        self.test_notebooks = [
-            new_notebook(cells=test_cells),
-            new_notebook(cells=[make_cell("print('Some code!')")] + test_cells),
-        ]
-
-    def setUp(self):
-        self.reset_cells()
-
-    def test_base_case(self):
-        "Checks if we can insert directly to the first cell"
-        self.notebook_processor = NotebookProcessor(
-            processors=[self.processor],
-            notebook=self.test_notebooks[0],
-        )
-        self.notebook_processor.process_notebook()
-        self.assertEqual(self.notebook_processor.notebook.cells[0].source, "# Test Notebook")
-        self.assertEqual(
-            self.notebook_processor.notebook.cells[1].source, f"{REFERENCE_JQUERY}\n{REFERENCE_JAVASCRIPT}"
-        )
-
-    def test_around_code_cell(self):
-        "Checks that it can be inserted under a markdown cell after a code cell in the very start"
-        self.notebook_processor = NotebookProcessor(
-            processors=[self.processor],
-            notebook=self.test_notebooks[1],
-        )
-        self.notebook_processor.process_notebook()
-        self.assertEqual(self.notebook_processor.notebook.cells[0].source, "print('Some code!')")
-        self.assertEqual(self.notebook_processor.notebook.cells[1].source, "# Test Notebook")
-        self.assertEqual(
-            self.notebook_processor.notebook.cells[2].source, f"{REFERENCE_JQUERY}\n{REFERENCE_JAVASCRIPT}"
-        )
+    def test_procesor(self):
+        content = "---\ntitle: Test Notebook\n---\n# Test Notebook"
+        processor = SemanticVersioningProcessor(content)
+        processed_content = processor.process()
+        self.assertEqual(processed_content, f"{REFERENCE_JQUERY}\n{REFERENCE_JAVASCRIPT}\n{content}")


### PR DESCRIPTION
This pr introduces a breaking change as we deal with < 0.1.0 and a young API. Once 0.1.0 is released a full deprecation cycle (2 full `0.x.0` versions) will be used for any API regressions.

This PR changes `processors` in the `config.yaml` file to be `notebook_processors` to introduce the concept of *`qmd_processors`*. As the name suggests, these are meant to apply some sort of post processing to all `.qmd` files in the docs in a *project-based* way. This is to help make https://github.com/muellerzr/nbquarto/issues/4 easier by allowing us to inject the javascript syntax needed at the top of each qmd, not just notebook. 

For now is just raw string modification on the qmd file, eventually might try to come up with a way to make it more notebook-esq